### PR TITLE
Introduce html5 atts in search form for mobile

### DIFF
--- a/templates/pageLayout.ihtml
+++ b/templates/pageLayout.ihtml
@@ -138,8 +138,7 @@
           {/if}
           <div id="searchArea">
             <form action="{$wwwRoot}search.php" name="frm" class="searchForm" onsubmit="return searchSubmit()">
-              <input type="text" name="cuv" size="15" value="{$cuv|escape}" maxlength="50" id="searchField"/>
-              <script type="text/javascript">document.frm.cuv.select();document.frm.cuv.focus();</script>
+              <input type="search" name="cuv" size="15" value="{$cuv|escape}" maxlength="50" id="searchField" autocomplete="off" autofocus />
               <span><input type="submit" value="caută" id="searchButton" /></span>
             </form>
           </div>


### PR DESCRIPTION
Scop: modificarea campului de cautare (input), din "text" in "search", care creaza un buton de close/stergere a intregului continut, pentru usurarea cautarii urmatorului cuvant.
Modificari testate pe urmatoarele browsere: Chrome 40.0.2214.111, Firefox 13.0.1, Opera 12.11 & IE 9.
