### PR TITLE
Adding hasAvatar user field (refs #341)

### DIFF
--- a/patches/00129.sql
+++ b/patches/00129.sql
@@ -1,0 +1,1 @@
+alter table User add hasAvatar tinyint(1) default 0;

--- a/patches/00130.php
+++ b/patches/00130.php
@@ -1,0 +1,17 @@
+<?php
+
+$f = new FtpUtil();
+$ftp_user_imgs = $f->staticServerRelativeFileList('img/user');
+
+$existing_user_imgs = array_map(function($item) {
+  $file = array_pop(explode('/', $item));
+  $id = reset(explode('.', $file));
+  return $id;
+}, $ftp_user_imgs);
+
+printf("Existing avatars: %s\n", count($existing_user_imgs));
+printf("Setting hasAvatar for users with avatars.\n");
+
+ORM::for_table('User')->where_id_in($existing_user_imgs)->find_result_set()->set('hasAvatar', 1)->save();
+
+?>

--- a/phplib/FtpUtil.php
+++ b/phplib/FtpUtil.php
@@ -2,7 +2,7 @@
 
 class FtpUtil {
   private $conn;
-  
+
   function __construct() {
     $user = Config::get('static.user');
     $pass = Config::get('static.password');
@@ -45,6 +45,11 @@ class FtpUtil {
     return !empty($listing);
   }
 
+  function staticServerRelativeFileList($rel_path) {
+    $path = sprintf("%s/%s", Config::get('static.path'), $rel_path);
+    $file_list = ftp_nlist($this->conn, $path);
+    return $file_list;
+  }
 }
 
 ?>

--- a/templates/bits/avatar.ihtml
+++ b/templates/bits/avatar.ihtml
@@ -1,5 +1,8 @@
 <img class="avatar"
+  {if $user->hasAvatar}
      src="{$staticServer}img/user/{$user->id}.jpg?cb={1000000000|rand:9999999999}"
+  {else}
+     src="{$imgRoot}/avatar_user.png"
+  {/if}
      alt="imagine de profil: {$user->nick|escape}"
-     onerror="this.src='{$imgRoot}/avatar_user.png';"
 />

--- a/wwwbase/salvare-avatar.php
+++ b/wwwbase/salvare-avatar.php
@@ -20,6 +20,8 @@ $delete = util_getRequestParameter('delete');
 if ($delete) {
   $f = new FtpUtil();
   $f->staticServerDelete($AVATAR_REMOTE_FILE);
+  $user->hasAvatar = 0;
+  $user->save();
   FlashMessage::add('Imaginea a fost ștearsă.', 'info');
   util_redirect('preferinte');
 }
@@ -41,6 +43,9 @@ $f = new FtpUtil();
 $f->staticServerPut($tmpFileName, $AVATAR_REMOTE_FILE);
 unlink($rawFileName);
 unlink($tmpFileName);
+
+$user->hasAvatar = 1;
+$user->save();
 
 FlashMessage::add('Imaginea a fost salvată.', 'info');
 util_redirect('preferinte');


### PR DESCRIPTION
* new function in `FtpUtil`: `staticServerRelativeFileList` that lists ftp
  contents relative to the config path
* setting `hasAvatar` on avatar save and delete
* removing onerror from `avatar.ihtml`
* migration steps:

    * 00129: add the new `hasAvatar` column to the `User` table
    * 00130: get image list from FTP:`/img/user/` and set `hasAvatar = 1`
      for matching user IDs