### PR TITLE
Autocomplete integration (#224)

### DIFF
--- a/dex.conf.sample
+++ b/dex.conf.sample
@@ -21,7 +21,7 @@ debugUser = ""
 ; True on development installations. Used to hide the Google analytics code and to allow fake user logins
 developmentMode = 0
 
-; API key for Google search of clones 
+; API key for Google search of clones
 googleSearchApiKey = "Insert your API key here"
 
 ; Show our web host logo
@@ -138,6 +138,13 @@ wotdSubscribe = false
 
 [limits]
 limitFulltextSearch = 200
+
+[search]
+acEnable = true
+acMinChars = 3
+;normal or inflected
+acSearchType = normal
+acLimit = 10
 
 ; Configuration for the Romanian literature crawler
 [crawler]

--- a/dex.conf.sample
+++ b/dex.conf.sample
@@ -142,8 +142,6 @@ limitFulltextSearch = 200
 [search]
 acEnable = true
 acMinChars = 3
-;normal or inflected
-acSearchType = normal
 acLimit = 10
 
 ; Configuration for the Romanian literature crawler

--- a/phplib/SmartyWrap.php
+++ b/phplib/SmartyWrap.php
@@ -23,14 +23,21 @@ class SmartyWrap {
     self::assign('developmentMode', Config::get('global.developmentMode'));
     self::assign('isMobile', util_isMobile());
     self::assign('suggestNoBanner', util_suggestNoBanner());
+    self::assign('acEnable',  Config::get('search.acEnable'));
+    self::assign('acMinChars', Config::get('search.acMinChars'));
     self::assign('GLOBALS', $GLOBALS);
     self::$theSmarty->registerPlugin('function', 'getDebugInfo', array('SmartyWrap', 'getDebugInfo'));
   }
 
   static function fetchSkin() {
     $skin = session_getSkin();
-    self::addCss($skin, 'jqueryui');
-    self::addJs('jquery', 'jqueryui', 'dex');
+    self::addCss($skin);
+    self::addJs('jquery', 'dex');
+    $acEnable = self::$theSmarty->tpl_vars['acEnable']->value;
+    if ($acEnable) {
+        self::addCss('jqueryui');
+        self::addJs('jqueryui');
+    }
     $skinVariables = array_merge(Config::getSection("skin-default"),
                                  Config::getSection("skin-{$skin}"));
     self::assign('skinVariables', $skinVariables);

--- a/phplib/SmartyWrap.php
+++ b/phplib/SmartyWrap.php
@@ -29,8 +29,8 @@ class SmartyWrap {
 
   static function fetchSkin() {
     $skin = session_getSkin();
-    self::addCss($skin);
-    self::addJs('jquery', 'dex');
+    self::addCss($skin, 'jqueryui');
+    self::addJs('jquery', 'jqueryui', 'dex');
     $skinVariables = array_merge(Config::getSection("skin-default"),
                                  Config::getSection("skin-{$skin}"));
     self::assign('skinVariables', $skinVariables);
@@ -44,7 +44,7 @@ class SmartyWrap {
   }
 
   static function fetchCommonPageWithSkin($templateName) {
-    self::assign('contentTemplateName', "$templateName");  
+    self::assign('contentTemplateName', "$templateName");
     return self::fetchSkin();
   }
 
@@ -121,8 +121,8 @@ class SmartyWrap {
         case 'lexemEdit':           self::$cssFiles[15] = 'lexemEdit.css?v=10'; break;
         case 'jcrop':               self::$cssFiles[16] = 'jcrop/jquery.Jcrop.min.css?v=3'; break;
         case 'select2':             self::$cssFiles[17] = 'select2/select2.css?v=3'; break;
-        case 'gallery':            
-          self::$cssFiles[18] = 'colorbox/colorbox.css?v=1'; 
+        case 'gallery':
+          self::$cssFiles[18] = 'colorbox/colorbox.css?v=1';
           self::$cssFiles[19] = 'visualDict.css?v=3';
           break;
         case 'textComplete':        self::$cssFiles[20] = 'jquery.textcomplete.css'; break;
@@ -137,7 +137,7 @@ class SmartyWrap {
     // Note the priorities. This allows files to be added in any order, regardless of dependencies
     foreach (func_get_args() as $id) {
       switch($id) {
-        case 'jquery':           self::$jsFiles[1] = 'jquery-1.10.2.min.js'; break; 
+        case 'jquery':           self::$jsFiles[1] = 'jquery-1.10.2.min.js'; break;
         case 'jqueryui':         self::$jsFiles[2] = 'jquery-ui-1.10.3.custom.min.js'; break;
         case 'jqgrid':
           self::$jsFiles[3] = 'grid.locale-en.js?v=2';
@@ -150,7 +150,7 @@ class SmartyWrap {
           self::$jsFiles[8] = 'tablesorter.dev.js?v=3';
           break;
         case 'pager':            self::$jsFiles[9] = 'jquery.tablesorter.pager.min.js'; break;
-        case 'elfinder':         self::$jsFiles[10] = 'elfinder.min.js?v=1'; break; 
+        case 'elfinder':         self::$jsFiles[10] = 'elfinder.min.js?v=1'; break;
         case 'windowEngine':     self::$jsFiles[11] = 'jquery-wm.js'; break;
         case 'cookie':           self::$jsFiles[12] = 'jquery.cookie.js?v=1'; break;
         case 'dex':              self::$jsFiles[13] = 'dex.js?v=29'; break;
@@ -164,7 +164,7 @@ class SmartyWrap {
         case 'select2Dev':       self::$jsFiles[21] = 'select2Dev.js?v=6'; break;
         case 'visual':           self::$jsFiles[22] = 'visual.js?v=2'; break;
         case 'visualTag':        self::$jsFiles[23] = 'visualTag.js?v=2'; break;
-        case 'gallery':          
+        case 'gallery':
           self::$jsFiles[24] = 'colorbox/jquery.colorbox-min.js';
           self::$jsFiles[25] = 'colorbox/jquery.colorbox-ro.js';
           self::$jsFiles[26] = 'dexGallery.js?v=2';

--- a/phplib/models/Lexem.php
+++ b/phplib/models/Lexem.php
@@ -132,7 +132,6 @@ class Lexem extends BaseObject implements DatedObject {
       ->where_like($field, $search)
       ->order_by_asc('formNoAccent')
       ->limit($limit)
-      ->distinct()
       ->find_many();
 
     if ($useMemcache) {

--- a/phplib/models/Lexem.php
+++ b/phplib/models/Lexem.php
@@ -141,32 +141,6 @@ class Lexem extends BaseObject implements DatedObject {
     return $result;
   }
 
-
-  public static function searchLikeInflectedForms($search, $hasDiacritics, $useMemcache = false, $limit = 10) {
-    if ($useMemcache) {
-      $key = "likeInflected_" . ($hasDiacritics ? '1' : '0') . "_$search";
-      $result = mc_get($key);
-      if ($result) {
-        return $result;
-      }
-    }
-    $field = $hasDiacritics ? 'formNoAccent' : 'formUtf8General';
-    $result = Model::factory('Lexem')
-      ->table_alias('l')
-      ->select('l.*')
-      ->distinct()
-      ->join('LexemModel', 'l.id = lm.lexemId', 'lm')
-      ->join('InflectedForm', 'lm.id = f.lexemModelId', 'f')
-      ->where_like("f.$field", $search)
-      ->order_by_asc('l.formNoAccent')
-      ->limit($limit)
-      ->find_many();
-    if ($useMemcache) {
-      mc_set($key, $result);
-    }
-    return $result;
-  }
-
   public static function searchInflectedForms($cuv, $hasDiacritics, $useMemcache = false) {
     if ($useMemcache) {
       $key = "inflected_" . ($hasDiacritics ? '1' : '0') . "_$cuv";

--- a/phplib/models/Lexem.php
+++ b/phplib/models/Lexem.php
@@ -118,6 +118,31 @@ class Lexem extends BaseObject implements DatedObject {
                       "and sourceId in (select id from Source where canDistribute) order by D.modDate, D.id");
   }
 
+  public static function searchLikeInflectedForms($search, $hasDiacritics, $useMemcache = false) {
+    if ($useMemcache) {
+      $key = "like_" . ($hasDiacritics ? '1' : '0') . "_$search";
+      $result = mc_get($key);
+      if ($result) {
+        return $result;
+      }
+    }
+    $field = $hasDiacritics ? 'formNoAccent' : 'formUtf8General';
+    $result = Model::factory('Lexem')
+      ->table_alias('l')
+      ->select('l.*')
+      ->distinct()
+      ->join('LexemModel', 'l.id = lm.lexemId', 'lm')
+      ->join('InflectedForm', 'lm.id = f.lexemModelId', 'f')
+      ->where_like("f.$field", $search)
+      ->order_by_asc('l.formNoAccent')
+      ->limit(10)
+      ->find_many();
+    if ($useMemcache) {
+      mc_set($key, $result);
+    }
+    return $result;
+  }
+
   public static function searchInflectedForms($cuv, $hasDiacritics, $useMemcache = false) {
     if ($useMemcache) {
       $key = "inflected_" . ($hasDiacritics ? '1' : '0') . "_$cuv";
@@ -160,7 +185,7 @@ class Lexem extends BaseObject implements DatedObject {
     $search_time = sprintf('%0.3f', $end - $start);
 /*
     $logArray = "";
-    foreach ($result as $word) {		
+    foreach ($result as $word) {
       $logArray = $logArray . " " . $word;
     }
     $logEntry = "$method\t$search_time\t$cuv:\t$logArray\t$leng\t" . count($result) . "\n";
@@ -294,7 +319,7 @@ class Lexem extends BaseObject implements DatedObject {
         } else {
           $lexem = Lexem::deepCreate($if->form, 'A', $pm->adjectiveModel, '', $this->isLoc());
           $lexem->deepSave();
-          
+
           // Also associate the new lexem with the same definitions as $this.
           $ldms = LexemDefinitionMap::get_all_by_lexemId($this->id);
           foreach ($ldms as $ldm) {
@@ -524,7 +549,7 @@ class Lexem extends BaseObject implements DatedObject {
 
     $clone->setLexemModels(array($lm));
     $clone->deepSave();
-    
+
     // Clone the definition list
     $ldms = LexemDefinitionMap::get_all_by_lexemId($this->id);
     foreach ($ldms as $ldm) {

--- a/templates/bits/searchForm.ihtml
+++ b/templates/bits/searchForm.ihtml
@@ -38,29 +38,38 @@
   };
   document.frm.cuv.addEventListener("keydown", slash, false);
 
-  var searchInput = $('.searchField');
-
   {/literal}
 
-  var searchCache = {};
+  {if $acEnable}
 
-  searchInput.autocomplete({
-    minLength: 2,
-    source: function(request, response){
-      var term = request.term;
-      if (term in searchCache){
-        response(searchCache[term]);
-        return;
-      }
-      $.getJSON('{$wwwRoot}searchcomplete.php', request, function(data, status, xhr){
-        searchCache[term] = data;
-        response(data);
+    (function(){
+
+      var searchForm = $('#searchForm');
+      var searchInput = $('.searchField');
+      var searchCache = {};
+      var minLength = {$acMinChars};
+
+      searchInput.autocomplete({
+        minLength: minLength,
+        source: function(request, response){
+          var term = request.term;
+          if (term in searchCache){
+            response(searchCache[term]);
+            return;
+          }
+          $.getJSON('{$wwwRoot}searchcomplete.php', request, function(data, status, xhr){
+            searchCache[term] = data;
+            response(data);
+          });
+        },
+        select: function(event, ui){
+          searchInput.val(ui.item.value);
+          searchForm.submit();
+        }
       });
-    },
-    select: function(event, ui){
-      searchInput.text(ui.value);
-      $('#searchForm').submit();
-    }
-  });
+
+    })();
+
+  {/if}
 
 </script>

--- a/templates/bits/searchForm.ihtml
+++ b/templates/bits/searchForm.ihtml
@@ -24,5 +24,9 @@
 </form>
 <div class="clearer"></div>
 <script type="text/javascript">
-  searchInit({$acMinChars});
+  {if $acEnable}
+    searchInit(true, {$acMinChars});
+  {else}
+    searchInit(false);
+  {/if}
 </script>

--- a/templates/bits/searchForm.ihtml
+++ b/templates/bits/searchForm.ihtml
@@ -1,8 +1,11 @@
 {assign var="advancedSearch" value=$advancedSearch|default:false}
 {assign var="cuv" value=$cuv|default:''}
 {assign var="text" value=$text|default:false}
+
+
+
 <form action="{$wwwRoot}search.php" name="frm" onsubmit="return searchSubmit()" id="searchForm">
-  
+
   <div class="searchTextField">
     <input type="text" name="cuv" class="searchField" value="{$cuv|escape}"  maxlength="50" title="Caută"/>
     <input type="submit" value="caută" id="searchButton" class="btn"/>
@@ -11,7 +14,7 @@
   {if !$advancedSearch}
     <a href="#" onclick="return toggleDivVisibility('advSearch')" id="advancedAnchor">căutare avansată</a>
   {/if}
-  
+
   <div id="advSearch" {if !$advancedSearch}style="display: none"{/if}>
     <input type="checkbox" name="text" value="1" id="defBody" {if $text}checked="checked"{/if}/>
     <label for="defBody">Caută în tot textul definițiilor</label>
@@ -19,12 +22,12 @@
     {include file="sourceDropDown.ihtml" urlName=1}
   </div>
 </form>
-<div class="clearer"></div> 
+<div class="clearer"></div>
 <script type="text/javascript">
   {literal}
   document.frm.cuv.select();
   document.frm.cuv.focus();
-  
+
   function slash(evt) { // ignore / and let it be used by the browser
     evt = evt || window.event;
     var charCode = evt.keyCode || evt.which;
@@ -34,5 +37,30 @@
     }
   };
   document.frm.cuv.addEventListener("keydown", slash, false);
+
+  var searchInput = $('.searchField');
+
   {/literal}
+
+  var searchCache = {};
+
+  searchInput.autocomplete({
+    minLength: 2,
+    source: function(request, response){
+      var term = request.term;
+      if (term in searchCache){
+        response(searchCache[term]);
+        return;
+      }
+      $.getJSON('{$wwwRoot}searchcomplete.php', request, function(data, status, xhr){
+        searchCache[term] = data;
+        response(data);
+      });
+    },
+    select: function(event, ui){
+      searchInput.text(ui.value);
+      $('#searchForm').submit();
+    }
+  });
+
 </script>

--- a/templates/bits/searchForm.ihtml
+++ b/templates/bits/searchForm.ihtml
@@ -24,52 +24,5 @@
 </form>
 <div class="clearer"></div>
 <script type="text/javascript">
-  {literal}
-  document.frm.cuv.select();
-  document.frm.cuv.focus();
-
-  function slash(evt) { // ignore / and let it be used by the browser
-    evt = evt || window.event;
-    var charCode = evt.keyCode || evt.which;
-    if (charCode == 191 && !evt.shiftKey) {
-      this.blur();
-      return false;
-    }
-  };
-  document.frm.cuv.addEventListener("keydown", slash, false);
-
-  {/literal}
-
-  {if $acEnable}
-
-    (function(){
-
-      var searchForm = $('#searchForm');
-      var searchInput = $('.searchField');
-      var searchCache = {};
-      var minLength = {$acMinChars};
-
-      searchInput.autocomplete({
-        minLength: minLength,
-        source: function(request, response){
-          var term = request.term;
-          if (term in searchCache){
-            response(searchCache[term]);
-            return;
-          }
-          $.getJSON('{$wwwRoot}searchcomplete.php', request, function(data, status, xhr){
-            searchCache[term] = data;
-            response(data);
-          });
-        },
-        select: function(event, ui){
-          searchInput.val(ui.item.value);
-          searchForm.submit();
-        }
-      });
-
-    })();
-
-  {/if}
-
+  searchInit({$acMinChars});
 </script>

--- a/wwwbase/js/dex.js
+++ b/wwwbase/js/dex.js
@@ -50,6 +50,56 @@ function searchSubmit() {
   return false;
 }
 
+
+function searchInitFocus() {
+  document.frm.cuv.select();
+  document.frm.cuv.focus();
+
+  function slash(evt) { // ignore / and let it be used by the browser
+    evt = evt || window.event;
+    var charCode = evt.keyCode || evt.which;
+    if (charCode == 191 && !evt.shiftKey) {
+      this.blur();
+      return false;
+    }
+  }
+
+  document.frm.cuv.addEventListener("keydown", slash, false);
+}
+
+
+function searchInitAutocomplete(acMinChars, wwwRoot){
+
+  var searchForm = $('#searchForm');
+  var searchInput = $('.searchField');
+  var searchCache = {};
+  var queryURL = wwwRoot + 'searchComplete.php';
+
+  searchInput.autocomplete({
+    minLength: acMinChars,
+    source: function(request, response){
+      var term = request.term;
+      if (term in searchCache){
+        response(searchCache[term]);
+        return;
+      }
+      $.getJSON(queryURL, request, function(data, status, xhr){
+        searchCache[term] = data;
+        response(data);
+      });
+    },
+    select: function(event, ui){
+      searchInput.val(ui.item.value);
+      searchForm.submit();
+    }
+  });
+}
+
+function searchInit(acMinChars) {
+  searchInitFocus();
+  searchInitAutocomplete(acMinChars, wwwRoot);
+}
+
 function getWwwRoot() {
   var pos = window.location.href.indexOf('/wwwbase/');
   if (pos == -1) {
@@ -272,7 +322,7 @@ function trim(str) {
 
 // Add/remove bookmarks
 function addBookmark(linkElement) {
-  var url = linkElement.attr('href'); 
+  var url = linkElement.attr('href');
   var ajaxLoader = createAjaxLoader();
 
   // show ajax indicator
@@ -347,7 +397,7 @@ function createAjaxLoader() {
   return $('<img src="' + wwwRoot + 'img/icons/ajax-indicator.gif" />');
 }
 
-if (typeof jQuery != 'undefined') { 
+if (typeof jQuery != 'undefined') {
   $(document).ready(function() {
     $('body').click(function() {
       $('#mainMenu li ul, #userMenu li ul').hide();

--- a/wwwbase/js/dex.js
+++ b/wwwbase/js/dex.js
@@ -95,9 +95,11 @@ function searchInitAutocomplete(acMinChars, wwwRoot){
   });
 }
 
-function searchInit(acMinChars) {
+function searchInit(acEnable, acMinChars) {
   searchInitFocus();
-  searchInitAutocomplete(acMinChars, wwwRoot);
+  if (acEnable) {
+    searchInitAutocomplete(acMinChars, wwwRoot);
+  }
 }
 
 function getWwwRoot() {

--- a/wwwbase/searchComplete.php
+++ b/wwwbase/searchComplete.php
@@ -1,6 +1,5 @@
 <?php
 require_once("../phplib/util.php");
-setlocale(LC_ALL, "ro_RO.utf8");
 header("Content-Type: application/json");
 
 

--- a/wwwbase/searchcomplete.php
+++ b/wwwbase/searchcomplete.php
@@ -6,7 +6,6 @@ header("Content-Type: application/json");
 
 $acEnable = Config::get("search.acEnable");
 $acMinChars = Config::get("search.acMinChars");
-$acSearchType = Config::get("search.acSearchType");
 $acLimit = Config::get("search.acLimit");
 
 $search = $_REQUEST["term"];
@@ -23,12 +22,7 @@ $hasDiacritics = session_user_prefers(Preferences::FORCE_DIACRITICS) || $arr[0];
 
 $sql_like = sprintf("%s%%", $search);
 
-
-if ($acSearchType == "inflected"){
-  $search_results = Lexem::searchLikeInflectedForms($sql_like, $hasDiacritics, true, $acLimit);
-} else if ($acSearchType == "normal") {
-  $search_results = Lexem::searchLike($sql_like, $hasDiacritics, true, $acLimit);
-}
+$search_results = Lexem::searchLike($sql_like, $hasDiacritics, true, $acLimit);
 
 
 $clean_results = array_map(function($lexem) use ($hasDiacritics){

--- a/wwwbase/searchcomplete.php
+++ b/wwwbase/searchcomplete.php
@@ -1,0 +1,40 @@
+<?php
+require_once("../phplib/util.php");
+setlocale(LC_ALL, "ro_RO.utf8");
+header('Content-Type: application/json');
+
+$search = $_REQUEST['term'];
+
+if (strlen($search) < 3) {
+    return print(json_encode(array()));
+}
+
+
+$LIKE = sprintf("%s%%", $search);
+
+
+
+$arr = StringUtil::analyzeQuery($search);
+$hasDiacritics = session_user_prefers(Preferences::FORCE_DIACRITICS) || $arr[0];
+
+$lexems = Lexem::searchLikeInflectedForms($LIKE, $hasDiacritics, true);
+
+// Alternate search directly and only in the Lexem table
+//$lexems = ORM::for_table('Lexem')
+//    ->where_like('formNoAccent', $LIKE)
+//    ->order_by_asc('formNoAccent')
+//    ->limit(5)
+//    ->find_many();
+
+$clean_results = array_map(function($lexem) use ($hasDiacritics){
+    if ($hasDiacritics) {
+        return $lexem->formNoAccent;
+    } else {
+        return $lexem->formUtf8General;
+    }
+}, $lexems);
+
+return print(json_encode($clean_results));
+
+?>
+

--- a/wwwbase/searchcomplete.php
+++ b/wwwbase/searchcomplete.php
@@ -1,38 +1,44 @@
 <?php
 require_once("../phplib/util.php");
 setlocale(LC_ALL, "ro_RO.utf8");
-header('Content-Type: application/json');
+header("Content-Type: application/json");
 
-$search = $_REQUEST['term'];
 
-if (strlen($search) < 3) {
-    return print(json_encode(array()));
+$acEnable = Config::get("search.acEnable");
+$acMinChars = Config::get("search.acMinChars");
+$acSearchType = Config::get("search.acSearchType");
+$acLimit = Config::get("search.acLimit");
+
+$search = $_REQUEST["term"];
+
+
+if (!$acEnable || strlen($search) < $acMinChars) {
+  return print(json_encode(array()));
 }
-
-
-$LIKE = sprintf("%s%%", $search);
-
 
 
 $arr = StringUtil::analyzeQuery($search);
 $hasDiacritics = session_user_prefers(Preferences::FORCE_DIACRITICS) || $arr[0];
 
-$lexems = Lexem::searchLikeInflectedForms($LIKE, $hasDiacritics, true);
 
-// Alternate search directly and only in the Lexem table
-//$lexems = ORM::for_table('Lexem')
-//    ->where_like('formNoAccent', $LIKE)
-//    ->order_by_asc('formNoAccent')
-//    ->limit(5)
-//    ->find_many();
+$sql_like = sprintf("%s%%", $search);
+
+
+if ($acSearchType == "inflected"){
+  $search_results = Lexem::searchLikeInflectedForms($sql_like, $hasDiacritics, true, $acLimit);
+} else if ($acSearchType == "normal") {
+  $search_results = Lexem::searchLike($sql_like, $hasDiacritics, true, $acLimit);
+}
+
 
 $clean_results = array_map(function($lexem) use ($hasDiacritics){
-    if ($hasDiacritics) {
-        return $lexem->formNoAccent;
-    } else {
-        return $lexem->formUtf8General;
-    }
-}, $lexems);
+  if ($hasDiacritics) {
+    return $lexem->formNoAccent;
+  } else {
+    return $lexem->formUtf8General;
+  }
+}, $search_results);
+
 
 return print(json_encode($clean_results));
 


### PR DESCRIPTION
Changes
* `searchLike` method on `Lexem` 
* new `search` section in config
* `jqueryui` now loaded on all pages if `search.acEnable = true`

Results are cached in several places so it should not have that big of impact on performance:
* jquery autocomplete only does the request once the user stops typing
* previous requests are cached client side (until page refresh)
* `searchLike` uses memcahe
* Varnish should be able to cache the `searchcomplete.php` requests without issues